### PR TITLE
fix(ci): bump Node 18 → 20 for pnpm/action-setup compatibility

### DIFF
--- a/.github/actions/setup-forge-env/action.yaml
+++ b/.github/actions/setup-forge-env/action.yaml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: 'Node.js version to install'
     required: false
-    default: '18'
+    default: '20'
   
   pnpm-version:
     description: 'pnpm version to install'

--- a/.github/workflows/forge-artifacts.yaml
+++ b/.github/workflows/forge-artifacts.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: "Install NodeJS"
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm

--- a/.github/workflows/forge-build.yaml
+++ b/.github/workflows/forge-build.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: "Install NodeJS"
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm

--- a/.github/workflows/forge-docs.yaml
+++ b/.github/workflows/forge-docs.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: "Install NodeJS"
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm

--- a/.github/workflows/forge-test-multi-account.yaml
+++ b/.github/workflows/forge-test-multi-account.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: "Install NodeJS"
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm

--- a/.github/workflows/forge-test-simulate.yaml
+++ b/.github/workflows/forge-test-simulate.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: "Install NodeJS"
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm

--- a/.github/workflows/forge-test.yaml
+++ b/.github/workflows/forge-test.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: "Install NodeJS"
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm


### PR DESCRIPTION
## Problem

`pnpm/action-setup`'s self-installer (`@pnpm/exe/setup.js`) now crashes on **Node 18**:

```
npm error command sh -c node setup.js   (~/setup-pnpm/node_modules/@pnpm/exe)
npm error TypeError [ERR_INVALID_ARG_TYPE]: The "paths[0]" argument must be of type string. Received undefined
npm error Node.js v18.20.8
##[error]Something went wrong, self-installer exits with code 1
```

This fails the **"Running self-installer"** step *before* any Forge build/lint runs, so it breaks CI for **every repo** consuming these reusable workflows. Node 18 is also being deprecated on GitHub runners.

Observed on `compact-utils#164`: `build / forge-build` (inline Node setup) and `lint / forge-lint` (Node setup via the `setup-forge-env` composite action) both die at the pnpm step.

## Fix

Bump `node-version` **18 → 20** everywhere Node is set up:
- 6 workflows with inline `actions/setup-node`: `forge-build`, `forge-test`, `forge-test-simulate`, `forge-test-multi-account`, `forge-docs`, `forge-artifacts`
- the `setup-forge-env` composite action default (used by `forge-lint`)

No other changes; `pnpm-version` (9.0.6) and action SHAs are untouched. Node 20 satisfies the pnpm self-installer and clears the runner deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)